### PR TITLE
Argument to add flags to IPMI commands in openpower systems

### DIFF
--- a/examples/POWER8/openpower.tcl
+++ b/examples/POWER8/openpower.tcl
@@ -8,18 +8,26 @@
 # Important globals. Change for your environment.
 #
 
-# Put the BMC IP address on the next line
-set ::bmc_address 127.0.0.1
-# IPMI account name for BMC
-set ::ipmi_user ADMIN
-# IPMI password
-set ::ipmi_passwd admin
+#Put the BMC IP address on the next line
+#set ::bmc_address 
+#IPMI account name for BMC
+#set ::ipmi_user 
+#IPMI password
+#set ::ipmi_passwd 
+
+#set ::ipmi_flags "-I lanplus -L OPERATOR"
 
 # Allow above to be placed on command line
-if {[llength $::script_argv] == 3} {
+if {[llength $::script_argv] >= 3} {
     set ::bmc_address [lindex $::script_argv 0]
     set ::ipmi_user [lindex $::script_argv 1]
     set ::ipmi_passwd [lindex $::script_argv 2]
+    if {[llength $::script_argv] > 2} {
+      set ::ipmi_flags [lindex $::script_argv 3]
+      for {set i 4} {$i < [llength $::script_argv]} {incr i} {
+        append ipmi_flags " " [lindex $::script_argv $i]
+      }
+    }
 } elseif {[llength $::script_argv] > 0} {
     puts "usage:  amester openpower.tcl <bmc_ip_addr> <userid> <password>"
     exit 0
@@ -74,7 +82,7 @@ set ::gui_parm_list {
 # ::amesterdebug::output $::thedebugfile
 
 # Connect to OpenPOWER system
-openpower myopenpower -addr $::bmc_address -ipmi_user $::ipmi_user -ipmi_passwd $::ipmi_passwd
+openpower myopenpower -addr $::bmc_address -ipmi_user $::ipmi_user -ipmi_passwd $::ipmi_passwd -ipmi_flags $ipmi_flags
 
 # Setup GUI
 foreach ame [find objects -isa ame] {

--- a/examples/POWER8/watchsensors.tcl
+++ b/examples/POWER8/watchsensors.tcl
@@ -18,11 +18,11 @@ set ::interval 0
 #Use "all" if you want to trace all sensors
 #set ::my_sensor_list "all"
 set ::my_sensor_list {
-    FREQA2MSP0
-    IPS2MSP0
-    PWR250US
-    TEMP2MSP0
-    VOLT250USP0V0
+  PWR250US
+  PWR250USP0
+  PWR250USVCS0
+  PWR250USVDD0
+  PWR250USMEM0
 }
 
 # Parameters to trace
@@ -51,6 +51,7 @@ set ::firstread "true"
 
 # Connect to the POWER server
 puts "Connecting to $::bmcaddr ..."
+puts "$::bmcflags"
 openpower mysys -addr $::bmcaddr -ipmi_user $::bmcusr -ipmi_passwd $::bmcpw -ipmi_flags $::bmcflags
 #localhost mysys
 
@@ -114,23 +115,28 @@ foreach amec $::theameclist {
 }
 
 # Print header
-puts -nonewline $::tracefp "AMESTER Date,AMESTER Time,"
+puts -nonewline $::tracefp "Time(ms),"
 foreach s $::allsensors {
     set shortName [regsub "^::" $s ""]
     puts -nonewline $::tracefp "$shortName,"
+    puts "$shortName"
 }
-foreach s $::allsensors {
-    set shortName [regsub "^::" $s ""]
-    puts -nonewline $::tracefp "$shortName acc,"
-    puts -nonewline $::tracefp "$shortName updates,"
-}
-foreach s $::allparms {
-    puts -nonewline $::tracefp "[$s cget -objname],"
-}
+#foreach s $::allsensors {
+    #set shortName [regsub "^::" $s ""]
+    ##puts -nonewline $::tracefp "$shortName acc,"
+    ##puts -nonewline $::tracefp "$shortName updates,"
+#}
+#foreach s $::allparms {
+    #puts -nonewline $::tracefp "[$s cget -objname],"
+#}
 puts $::tracefp ""
 flush $::tracefp
+#OLD
+#set ::starttime [clock clicks -milliseconds]
+#proc timestamp {} { return [clock format [clock seconds] -format "%D,%T"]}
 set ::starttime [clock clicks -milliseconds]
-proc timestamp {} { return [clock format [clock seconds] -format "%D,%T"]}
+proc timestamp {} { return [expr [clock clicks -milliseconds] - $::starttime]}
+
 # Set the callback for all sensor data updates
 set ::new_data_callback my_data_callback
 
@@ -210,14 +216,14 @@ proc my_data_callback {sensorobj} {
         #Print the accumulator values for each sensor and the number
         #of internal updates. Use for precise averages over any time
         #period.
-      foreach s $::allsensors {
-          puts -nonewline  $::tracefp "[$s cget -value_acc],"
-          puts -nonewline  $::tracefp "[$s cget -updates],"
-      }
+      #foreach s $::allsensors {
+          #puts -nonewline  $::tracefp "[$s cget -value_acc],"
+          #puts -nonewline  $::tracefp "[$s cget -updates],"
+      #}
 
         #Call procedure pointer to read and print parameters
         #for this AME API version
-        $::read_and_print_parameters_proc
+        #$::read_and_print_parameters_proc
 
       puts $::tracefp ""
       flush $::tracefp

--- a/examples/POWER8/watchsensors.tcl
+++ b/examples/POWER8/watchsensors.tcl
@@ -203,26 +203,26 @@ proc my_data_callback {sensorobj} {
     if {$sensorobj != [lindex $::allsensors end]} {return}
     # emit readings
     if {$::firstread eq "false"} { 
-  puts -nonewline $::tracefp "[timestamp],"
-  foreach s $::allsensors {
-      puts -nonewline  $::tracefp "[$s cget -value],"
-  }
+      puts -nonewline $::tracefp "[timestamp],"
+      foreach s $::allsensors {
+          puts -nonewline  $::tracefp "[$s cget -value],"
+      }
         #Print the accumulator values for each sensor and the number
         #of internal updates. Use for precise averages over any time
         #period.
-  foreach s $::allsensors {
-      puts -nonewline  $::tracefp "[$s cget -value_acc],"
-      puts -nonewline  $::tracefp "[$s cget -updates],"
-  }
+      foreach s $::allsensors {
+          puts -nonewline  $::tracefp "[$s cget -value_acc],"
+          puts -nonewline  $::tracefp "[$s cget -updates],"
+      }
 
         #Call procedure pointer to read and print parameters
         #for this AME API version
         $::read_and_print_parameters_proc
 
-  puts $::tracefp ""
-  flush $::tracefp
+      puts $::tracefp ""
+      flush $::tracefp
     }  else { 
-  set ::firstread "false" 
+      set ::firstread "false" 
     } 
     # Pause before printing next line
     after $::interval

--- a/examples/POWER8/watchsensors.tcl
+++ b/examples/POWER8/watchsensors.tcl
@@ -31,13 +31,19 @@ set ::my_parm_list {
 }
 
 if {[llength $::script_argv] < 4} {
-    puts "usage:  amester --nogui watchsensors.tcl <bmc ip addr> <bmc user> <bmc pw> <output filename | stdout>"
+    puts "usage:  amester --nogui watchsensors.tcl <bmc ip addr> <bmc user> <bmc pw> <output filename | stdout> <ipmi flags>"
     exit 0;
 } else {
     set ::bmcaddr [lindex $::script_argv 0]
     set ::bmcusr [lindex $::script_argv 1]
     set ::bmcpw [lindex $::script_argv 2]
     set ::tracefile [lindex $::script_argv 3]
+    if {[llength $::script_argv] > 3} {
+      set ::bmcflags [lindex $::script_argv 4]
+      for {set i 5} {$i < [llength $::script_argv]} {incr i} {
+        append bmcflags " " [lindex $::script_argv $i]
+      }
+    }
 }
 
 
@@ -45,7 +51,7 @@ set ::firstread "true"
 
 # Connect to the POWER server
 puts "Connecting to $::bmcaddr ..."
-openpower mysys -addr $::bmcaddr -ipmi_user $::bmcusr -ipmi_passwd $::bmcpw
+openpower mysys -addr $::bmcaddr -ipmi_user $::bmcusr -ipmi_passwd $::bmcpw -ipmi_flags $::bmcflags
 #localhost mysys
 
 # Either set the AMEC to trace manually, or trace all.
@@ -94,12 +100,12 @@ set ::allsensors {}
 set ::allparms {}
 foreach amec $::theameclist {
     if {$::my_sensor_list eq "all"} {
-	set allsensorobjs [$amec get sensors]
-	set allsensornames {}
-	foreach s $allsensorobjs {
-	    lappend allsensornames [$s cget -sensorname]
-	}
-	set ::my_sensor_list [lsort -ascii $allsensornames]
+  set allsensorobjs [$amec get sensors]
+  set allsensornames {}
+  foreach s $allsensorobjs {
+      lappend allsensornames [$s cget -sensorname]
+  }
+  set ::my_sensor_list [lsort -ascii $allsensornames]
     }
     $amec set_sensor_list $::my_sensor_list
     # Make allsensors, a list of all sensor objects
@@ -197,27 +203,28 @@ proc my_data_callback {sensorobj} {
     if {$sensorobj != [lindex $::allsensors end]} {return}
     # emit readings
     if {$::firstread eq "false"} { 
-	puts -nonewline $::tracefp "[timestamp],"
-	foreach s $::allsensors {
-	    puts -nonewline  $::tracefp "[$s cget -value],"
-	}
+  puts -nonewline $::tracefp "[timestamp],"
+  foreach s $::allsensors {
+      puts -nonewline  $::tracefp "[$s cget -value],"
+  }
         #Print the accumulator values for each sensor and the number
         #of internal updates. Use for precise averages over any time
         #period.
-	foreach s $::allsensors {
-	    puts -nonewline  $::tracefp "[$s cget -value_acc],"
-	    puts -nonewline  $::tracefp "[$s cget -updates],"
-	}
+  foreach s $::allsensors {
+      puts -nonewline  $::tracefp "[$s cget -value_acc],"
+      puts -nonewline  $::tracefp "[$s cget -updates],"
+  }
 
         #Call procedure pointer to read and print parameters
         #for this AME API version
         $::read_and_print_parameters_proc
 
-	puts $::tracefp ""
-	flush $::tracefp
+  puts $::tracefp ""
+  flush $::tracefp
     }  else { 
-	set ::firstread "false" 
+  set ::firstread "false" 
     } 
     # Pause before printing next line
     after $::interval
 }
+

--- a/vfs/lib/app-amester/openpower.itcl
+++ b/vfs/lib/app-amester/openpower.itcl
@@ -283,7 +283,6 @@ body openpower::find_occ_instance2 {} {
     set errorcode ""
     set result ""
 
-    set ipmicmd "$ipmi_ipmitool -H $addr -U $ipmi_user -P $ipmi_passwd $ipmi_flags"
     ::amesterdebug::debug openpower "trying |$ipmicmd fru list"
     if {[catch {
 	set f1 [open "|$ipmicmd fru list" r]
@@ -308,11 +307,11 @@ body openpower::find_occ_instance2 {} {
         }
 	}
 
+    #if { $_module_count < $_proc_count} {
     if { $_module_count < $_proc_count} {
         set _proc_count $_module_count
         ::amesterdebug::debug openpower "CPU # different than PROC MODULE use MODULE count =$ _proc_count"
     }
-
     if {[catch {close $f1} closeresult]} {
 	set n 0
 	foreach w [split $closeresult] {

--- a/vfs/lib/app-amester/openpower.itcl
+++ b/vfs/lib/app-amester/openpower.itcl
@@ -105,6 +105,7 @@ class openpower {
     public variable ipmi_user ""
     public variable ipmi_passwd ""
     public variable ipmi_ipmitool "ipmitool"
+    public variable ipmi_flags ""
 
     #Parameters
     protected variable vpdversion ""
@@ -157,7 +158,6 @@ class openpower {
 	# Cancel any pending afters
 	after cancel $ipmi_health_after
     }
-
     # Get basic info on openpower (initialization)
     public method init {}
 
@@ -282,7 +282,8 @@ body openpower::find_occ_instance2 {} {
     #Put spaces between each byte in data parameter
     set errorcode ""
     set result ""
-    set ipmicmd "$ipmi_ipmitool -H $addr -U $ipmi_user -P $ipmi_passwd"
+
+    set ipmicmd "$ipmi_ipmitool -H $addr -U $ipmi_user -P $ipmi_passwd $ipmi_flags"
     ::amesterdebug::debug openpower "trying |$ipmicmd fru list"
     if {[catch {
 	set f1 [open "|$ipmicmd fru list" r]
@@ -853,7 +854,7 @@ body openpower::ipmi_thread_start_openipmi {} {
     #end set ithread
 
     #Setup ithread
-    set ipmicmd "$ipmi_ipmitool -H $addr -U $ipmi_user -P $ipmi_passwd"
+    set ipmicmd "$ipmi_ipmitool -H $addr -U $ipmi_user -P $ipmi_passwd $ipmi_flags"
 
     thread::send $ithread [list set obj $this]
     if {$ipmicmd ne ""} {


### PR DESCRIPTION
I need to use several flags to be able to connect to my openpower system.
Since I don't know much tcl, files examples/POWER/{openpower,watchsensors}.tcl could read arguments in a more elegant way.